### PR TITLE
Use Somnus API instead of mixins for coffin sleeping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ repositories {
         name = "patchouli"
         url = "https://maven.blamejared.com"
     }
+    maven {
+        name = "somnus"
+        url = "https://maven.theillusivec4.top"
+    }
 }
 
 dependencies {
@@ -60,6 +64,8 @@ dependencies {
     modImplementation "io.github.ladysnake:Impersonate:${impersonate_version}"
     modImplementation "vazkii.patchouli:Patchouli:${project.patchouli_version}"
     modImplementation "com.github.emilyalexandra:trinkets:${trinkets_version}"
+    modImplementation "top.theillusivec4.somnus:somnus-fabric:${somnus_version}"
+    include "top.theillusivec4.somnus:somnus-fabric:${somnus_version}"
 
     modCompileOnly "me.shedaniel:RoughlyEnoughItems-api:${project.rei_version}"
     modRuntime "me.shedaniel:RoughlyEnoughItems:${project.rei_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ impersonate_version=2.1.0
 patchouli_version=1.16.4-48-FABRIC
 trinkets_version=2.6.7
 rei_version=5.10.181
+somnus_version=0.0.10-1.16.4

--- a/src/main/java/moriyashiine/bewitchment/mixin/BedBlockMixin.java
+++ b/src/main/java/moriyashiine/bewitchment/mixin/BedBlockMixin.java
@@ -27,18 +27,4 @@ public class BedBlockMixin {
 			callbackInfo.setReturnValue(ActionResult.success(!world.isClient));
 		}
 	}
-	
-	@Inject(method = "onUse", at = @At(value = "INVOKE", shift = At.Shift.BEFORE, target = "Lnet/minecraft/entity/player/PlayerEntity;trySleep(Lnet/minecraft/util/math/BlockPos;)Lcom/mojang/datafixers/util/Either;"), cancellable = true)
-	private void trySleep(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit, CallbackInfoReturnable<ActionResult> callbackInfo) {
-		if (state.getBlock() instanceof CoffinBlock) {
-			if (world.isDay()) {
-				player.trySleep(pos);
-				player.sleep(pos);
-			}
-			else {
-				player.sendMessage(new TranslatableText("block.minecraft.bed.coffin"), true);
-			}
-			callbackInfo.setReturnValue(ActionResult.SUCCESS);
-		}
-	}
 }

--- a/src/main/java/moriyashiine/bewitchment/mixin/PlayerEntityMixin.java
+++ b/src/main/java/moriyashiine/bewitchment/mixin/PlayerEntityMixin.java
@@ -278,15 +278,6 @@ public abstract class PlayerEntityMixin extends LivingEntity implements MagicAcc
 		return exhaustion;
 	}
 	
-	@Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;isDay()Z"))
-	private boolean coffinHack(World obj) {
-		Optional<BlockPos> pos = getSleepingPosition();
-		if (pos.isPresent() && world.getBlockState(pos.get()).getBlock() instanceof CoffinBlock) {
-			return obj.isNight();
-		}
-		return obj.isDay();
-	}
-	
 	@Inject(method = "getHurtSound", at = @At("HEAD"))
 	private void getHurtSound(DamageSource source, CallbackInfoReturnable<SoundEvent> callbackInfo) {
 		if (source == BWDamageSources.SUN) {

--- a/src/main/java/moriyashiine/bewitchment/mixin/ServerWorldMixin.java
+++ b/src/main/java/moriyashiine/bewitchment/mixin/ServerWorldMixin.java
@@ -61,29 +61,4 @@ public abstract class ServerWorldMixin extends World {
 			}
 		}
 	}
-	
-	@Inject(method = "tick", at = @At("HEAD"))
-	private void tick(BooleanSupplier shouldKeepTicking, CallbackInfo callbackInfo) {
-		boolean areAllPlayersAsleep = false;
-		for (PlayerEntity playerEntity : players) {
-			if (playerEntity.getSleepingPosition().isPresent() && playerEntity.isSleepingLongEnough() && getBlockState(playerEntity.getSleepingPosition().get()).getBlock() instanceof CoffinBlock) {
-				areAllPlayersAsleep = true;
-			}
-			else {
-				areAllPlayersAsleep = false;
-				break;
-			}
-		}
-		if (areAllPlayersAsleep) {
-			if (getGameRules().getBoolean(GameRules.DO_DAYLIGHT_CYCLE)) {
-				while (getTimeOfDay() % 24000 < 13000) {
-					setTimeOfDay(getTimeOfDay() + 1);
-				}
-			}
-			wakeSleepingPlayers();
-			if (getGameRules().getBoolean(GameRules.DO_WEATHER_CYCLE)) {
-				resetWeather();
-			}
-		}
-	}
 }


### PR DESCRIPTION
This PR replaces the mixins used to implement coffin sleeping with Somnus API. This makes Bewitchment compatible with Comforts and Haema.

I'm not sure if you'd prefer the events where they are if there's a more appropriate place for them.

There is one unintentional change in behaviour - the "you can only sleep at night or during thunderstorms" message is given to the player when "you can only sleep in day" should be. This will probably require a PR to Somnus to fix.

Fixes #29.

[Video](https://cdn.discordapp.com/attachments/523251999899385875/814956453059100692/2021-02-26_20-17-18.mp4)