### PR TITLE
Allow nametags to prevent werewolf villagers from despawning

### DIFF
--- a/src/main/java/moriyashiine/bewitchment/common/component/entity/WerewolfVillagerComponent.java
+++ b/src/main/java/moriyashiine/bewitchment/common/component/entity/WerewolfVillagerComponent.java
@@ -47,13 +47,13 @@ public class WerewolfVillagerComponent implements ServerTickingComponent {
 	@Override
 	public void serverTick() {
 		if (getStoredWerewolf() != null) {
-			if (getDespawnTimer() > 0) {
+			if (!obj.hasCustomName() && getDespawnTimer() > 0) {
 				setDespawnTimer(getDespawnTimer() - 1);
 				if (getDespawnTimer() == 0) {
 					obj.remove(Entity.RemovalReason.DISCARDED);
 				}
 			}
-			if (obj.age % 20 == 0 && obj.world.isNight() && BewitchmentAPI.getMoonPhase(obj.world) == 0 && obj.world.isSkyVisible(obj.getBlockPos())) {
+			if (obj.age % 20 == 0 && obj.world.isNight() && BewitchmentAPI.getMoonPhase(obj.world) == 0 && (obj.hasCustomName() || obj.world.isSkyVisible(obj.getBlockPos()))) {
 				WerewolfEntity entity = BWEntityTypes.WEREWOLF.create(obj.world);
 				if (entity != null) {
 					PlayerLookup.tracking(obj).forEach(trackingPlayer -> SpawnSmokeParticlesPacket.send(trackingPlayer, obj));
@@ -68,7 +68,7 @@ public class WerewolfVillagerComponent implements ServerTickingComponent {
 						entityCursesComponent.getCurses().clear();
 						thisCursesComponent.getCurses().forEach(entityCursesComponent::addCurse);
 					}));
-					if (getDespawnTimer() >= 0) {
+					if (!obj.hasCustomName() && getDespawnTimer() >= 0) {
 						setDespawnTimer(2400);
 					}
 					entity.storedVillager = obj.writeNbt(new NbtCompound());

--- a/src/main/java/moriyashiine/bewitchment/common/entity/living/WerewolfEntity.java
+++ b/src/main/java/moriyashiine/bewitchment/common/entity/living/WerewolfEntity.java
@@ -133,7 +133,7 @@ public class WerewolfEntity extends BWHostileEntity {
 				dataTracker.set(VARIANT, random.nextInt(getVariants() - 1) + 1);
 			}
 		}
-		if (spawnReason == SpawnReason.NATURAL) {
+		if (spawnReason == SpawnReason.NATURAL || spawnReason == SpawnReason.SPAWN_EGG) {
 			storedVillager = EntityType.VILLAGER.create((World) world).writeNbt(new NbtCompound());
 		}
 		return data;


### PR DESCRIPTION
- **WerewolfVillagerComponent**, add checks for a custom name before setting and acting upon the despawn timer
- **WerewolfVillagerComponent**, add a check for custom name to cause tagged werewolves to transform even if not exposed to direct moon light, this one might be  slightly out of scope but allows for more interesting uses for tagged werewolves.
- **WerewolfEntity**, create a stored villager when using a spawn egg, mostly QoL for testing the above patches